### PR TITLE
Doug/switch to full scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ The connectors supported by this script have some shared configuration in order 
 | from_time           | False    | int              | This is the number of seconds to pull reports from. If this is not defined then it will pull the last 30 days of reports.                   |
 | report_id           | False    | Socket Report ID | If this is provided then only the specified report ID will be processed                                                                     |
 | request_timeout     | False    | int              | This is the number of seconds to wait for an API request to complete before killing it and returning an error. Defaults to 30 seconds       |
-| default_branches    | False    | list[str]        | Only required if `default_branch_only` is set to specify the names patterns of default branches like `main` or `master`                     |
-| default_branch_only | False    | boolean          | If enabled only reports where the branch name matches what is in `default_branches` will be kept                                            |
+| default_branch_only | False    | boolean          | If enabled only reports where the branch name matches what is the latest report for each default branch per repo                            |
 | from_time           | False    | int              | Period in seconds to pull reports when not specifying a specific `report_id`. If not set defaults to 30 days                                |
 | actions_override    | False    | list[str]        | List of acceptable values to override the security policy configuration of issues to include. I.E. `error`, `warn`, `monitor`, and `ignore` |
 

--- a/socket-integration-example.py
+++ b/socket-integration-example.py
@@ -20,9 +20,7 @@ if __name__ == '__main__':
     core = Core(
         api_key=api_key,
         from_time=from_time,
-        default_branch_only=False,
-        request_timeout=300,
-        actions_override=["warn"]
+        request_timeout=300
     )
     # logging.basicConfig(level=logging.DEBUG)
     # core.set_log_level(logging.DEBUG)

--- a/socketsync/__init__.py
+++ b/socketsync/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 
 __author__ = 'socket.dev'
-__version__ = '1.0.8'
+__version__ = '1.0.11'
 __all__ = [
     "log",
     "__version__",

--- a/socketsync/classes.py
+++ b/socketsync/classes.py
@@ -19,15 +19,24 @@ __all__ = [
 
 
 class Report:
-    branch: str
-    commit: str
     id: str
+    created_at: str
+    updated_at: str
+    organization_id: str
+    repository_id: str
+    committers: list
+    branch: str
+    commit_message: str
+    commit: str
+    commit_hash: str
     pull_requests: list
+    pull_request: int
     url: str
+    html_report_url: str
     repo: str
     processed: bool
     owner: str
-    created_at: str
+    organization_slug: str
     sbom: list
 
     def __init__(self, **kwargs):
@@ -37,9 +46,22 @@ class Report:
                 setattr(self, key, value)
         if not hasattr(self, "processed"):
             self.processed = False
+        if not hasattr(self, "pull_request"):
+            self.pull_request = 0
+        if not hasattr(self, 'owner'):
+            self.owner = self.organization_slug
         if hasattr(self, "pull_requests"):
             if self.pull_requests is not None:
                 self.pull_requests = json.loads(str(self.pull_requests))
+            elif self.pull_request is not None and self.pull_request != 0:
+                self.pull_requests = [self.pull_request]
+        if not hasattr(self, 'pull_requests') and hasattr(self, 'pull_request'):
+            self.pull_requests = [self.pull_request]
+        if self.html_report_url is not None:
+            self.url = self.html_report_url
+        if not hasattr(self, 'commit'):
+            self.commit = self.commit_hash
+
 
     def __str__(self):
         return json.dumps(self.__dict__)


### PR DESCRIPTION
Migration of the Socket Sync to the Full Scans endpoint. This does the following:

1. Deprecates the use of the report/list and sbom/view endpoints
2. Makes use of the full scans endpoints `streaming` and `metadata`
3. Makes use of the `orgs/:org_id/repos` endpoint to get metadata for full scans for the default branch